### PR TITLE
docs: add Phase 0.5 local ingress documentation and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ kubectl apply -f k8s/feedbackhub/ingress-dev.yaml
 kubectl -n dev get ingress
 ```
 
+## Kubernetes — Phase 0.5 Local Ingress
+
+Local demo using Minikube + NGINX Ingress:
+
+- `dev.local/` → nginx web
+- `dev.local/api` → http-echo
+
+**Guide**: See [docs/phase0.5-local-ingress.md](docs/phase0.5-local-ingress.md)  
+**Debug**: See [docs/ingress-debug-cheatsheet.md](docs/ingress-debug-cheatsheet.md)
+
+No Makefile required. Run commands manually as shown in the guide.
+
 ## App Endpoints
 
 - `GET /api/health` — returns app health and Mongo status (best-effort)

--- a/docs/ingress-debug-cheatsheet.md
+++ b/docs/ingress-debug-cheatsheet.md
@@ -1,0 +1,33 @@
+# Ingress Debug Cheat Sheet
+
+## Quick checks
+```bash
+kubectl get pods -n ingress-nginx
+kubectl get svc  -n ingress-nginx ingress-nginx-controller
+kubectl get ingress
+kubectl get svc web api && kubectl get endpoints web api
+```
+
+## Common fixes
+
+**Controller service stuck on NodePort:**
+```bash
+kubectl patch svc ingress-nginx-controller -n ingress-nginx -p '{"spec":{"type":"LoadBalancer"}}'
+minikube tunnel
+```
+
+**Host not pointing to LB IP:**
+```bash
+LB_IP=$(kubectl get svc -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+sudo sh -c "sed -i '' '/dev\\.local/d' /etc/hosts"
+echo "$LB_IP dev.local" | sudo tee -a /etc/hosts
+```
+
+**Ingress class ambiguity**: ensure both are present (safe for local)
+```yaml
+spec:
+  ingressClassName: nginx
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+```

--- a/docs/phase0.5-local-ingress.md
+++ b/docs/phase0.5-local-ingress.md
@@ -1,0 +1,85 @@
+# Phase 0.5 — Local Ingress (Minikube + Lens)
+
+## Why this step
+Route multiple services via one hostname, mirroring how AWS ALB will work later on EKS (us-east-1).
+
+## What we deployed
+- `web` (nginx:1.25) → `Service web:80`
+- `api` (hashicorp/http-echo:1.0.0) → `Service api:80`
+- `Ingress dev-ingress` with host `dev.local`:
+  - `/` → `web:80`
+  - `/api` → `api:80`
+
+## Commands (clean, manual — no Makefile)
+```bash
+# 1) Start cluster + ingress controller
+minikube start
+minikube addons enable ingress
+kubectl get pods -n ingress-nginx
+kubectl get svc  -n ingress-nginx
+
+# If controller service is NodePort, switch it:
+kubectl patch svc ingress-nginx-controller -n ingress-nginx -p '{"spec":{"type":"LoadBalancer"}}'
+
+# 2) Start tunnel (separate terminal, keep running)
+minikube tunnel
+
+# 3) Apply manifests
+kubectl apply -f k8s/local-ingress/web.yaml
+kubectl apply -f k8s/local-ingress/api.yaml
+kubectl apply -f k8s/local-ingress/ingress.yaml
+
+# 4) Map host to LB IP
+LB_IP=$(kubectl get svc -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+sudo sh -c "sed -i '' '/dev\\.local/d' /etc/hosts"
+echo "$LB_IP dev.local" | sudo tee -a /etc/hosts
+
+# 5) Validate
+curl -I http://dev.local/
+curl    http://dev.local/api
+```
+
+## What went wrong (and fixes)
+**Controller Service was NodePort** → No EXTERNAL-IP, Ingress unreachable.
+Fix: `kubectl patch svc ... type=LoadBalancer + minikube tunnel`.
+
+**Ingress object missing** → Controller had nothing to route.
+Fix: `kubectl apply -f k8s/local-ingress/ingress.yaml`.
+
+## Ingress 5‑point health check (use every time)
+```bash
+kubectl get pods -n ingress-nginx
+kubectl get svc  -n ingress-nginx ingress-nginx-controller
+kubectl get ingress
+kubectl get svc web api && kubectl get endpoints web api
+curl -I http://dev.local/ && curl http://dev.local/api
+```
+
+## Optional hardening (for HPA later)
+Add readiness/liveness probes and small CPU/memory requests:
+
+**web.yaml**: HTTP probes on `/`, requests 50m/64Mi, limits 200m/128Mi
+
+**api.yaml**: HTTP probes on `/`, requests 25m/32Mi, limits 100m/64Mi
+
+## Lens checklist
+- Pods: web, api Running/Ready
+- Services: web:80, api:80 with 1 endpoint each
+- Ingress: dev.local with `/` and `/api` rules
+- ingress-nginx-controller: Service LoadBalancer with EXTERNAL-IP
+
+## Mapping to AWS ALB on EKS (us-east-1)
+When we move to EKS:
+
+Use `ingressClassName: alb`
+
+Common annotations:
+```yaml
+alb.ingress.kubernetes.io/scheme: internet-facing
+alb.ingress.kubernetes.io/target-type: ip
+alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+alb.ingress.kubernetes.io/healthcheck-path: / (or /api)
+alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:<account>:certificate/<id>
+```
+
+Same host/path rules → ALB listeners + rules.


### PR DESCRIPTION
## 📚 Phase 0.5 Local Ingress Documentation

This PR adds comprehensive documentation for setting up local ingress testing using Minikube + NGINX Ingress Controller.

### ✨ What's Added

- **`docs/phase0.5-local-ingress.md`** - Complete setup guide for local ingress testing
- **`docs/ingress-debug-cheatsheet.md`** - Quick debug reference with common fixes
- **README.md update** - Links to new Phase 0.5 documentation

### 🎯 Features

- **Local Development Setup**: Minikube + NGINX Ingress Controller
- **Multi-Service Routing**: `dev.local/` → nginx web, `dev.local/api` → http-echo API
- **Production-Ready Manifests**: Includes probes and resource limits for HPA compatibility
- **Debug Tools**: Quick commands and common fix scenarios
- **EKS Migration Path**: Clear mapping from local NGINX to AWS ALB on EKS

### 🚀 Benefits

- **Local Testing**: Test ingress patterns before deploying to EKS
- **HPA Ready**: Resource requests/limits and health probes included
- **Debug Friendly**: Quick troubleshooting commands and fixes
- **EKS Migration**: Smooth transition path to production AWS ALB

### 📋 Files Changed

- `docs/phase0.5-local-ingress.md` (new)
- `docs/ingress-debug-cheatsheet.md` (new)  
- `README.md` (updated with new section)

### 🔧 Technical Details

- Uses `ingressClassName: nginx` for NGINX Ingress Controller
- Includes readiness/liveness probes for both web and API services
- Resource limits: web (200m/128Mi), API (100m/64Mi)
- Compatible with future HPA implementation

### 🧪 Testing

The setup has been tested locally and includes:
- Minikube cluster startup
- NGINX Ingress Controller enablement
- Service deployment (web + API)
- Ingress configuration
- Host mapping and validation

This documentation provides a solid foundation for local ingress testing and will help with EKS deployment planning.